### PR TITLE
Fix for NEURON 9

### DIFF
--- a/mods/netstim125.mod
+++ b/mods/netstim125.mod
@@ -74,7 +74,6 @@ FUNCTION invl(mean (ms)) (ms) {
 }
 VERBATIM
 double nrn_random_pick(void* r);
-void* nrn_random_arg(int argpos);
 ENDVERBATIM
 
 FUNCTION erand() {

--- a/mods/netstimbox.mod
+++ b/mods/netstimbox.mod
@@ -34,7 +34,6 @@ FUNCTION invl(mean (ms)) (ms) {
 }	
 VERBATIM
 double nrn_random_pick(void* r);
-void* nrn_random_arg(int argpos);
 ENDVERBATIM
 
 FUNCTION erand() {

--- a/mods/netstimosc.mod
+++ b/mods/netstimosc.mod
@@ -75,7 +75,6 @@ FUNCTION invl(mean (ms)) (ms) {
 }
 VERBATIM
 double nrn_random_pick(void* r);
-void* nrn_random_arg(int argpos);
 ENDVERBATIM
 
 FUNCTION erand() {


### PR DESCRIPTION
Some of the function declarations in the mod files have incorrect types, so they do not work when using NEURON 9, see [here](https://nrn.readthedocs.io/en/latest/guide/porting_mechanisms_to_cpp.html#function-declarations-with-incorrect-types) for more details.